### PR TITLE
Simplify publish

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,6 @@ machine:
 
 dependencies:
   pre:
-    - "curl http://beyondgrep.com/ack-2.14-single-file > ~/bin/ack && chmod 0755 ~/bin/ack"
     - |
       if [[ ! -e ~/.yarn/bin/yarn || $(yarn --version) != "${YARN_VERSION}" ]]; then
         echo "Download and install Yarn."

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "repository": "https://github.com/Shopify/babel-preset-shopify",
   "scripts": {
     "check": "yarn run lint",
-    "deploy": "npm publish",
     "lint": "eslint --max-warnings=0 ."
   },
   "license": "MIT",

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,4 +1,0 @@
-deploy:
-  override:
-    - npm install --no-progress
-    - npm run deploy


### PR DESCRIPTION
Publish via shipit's new npm support.

Also removing `ack` download from the CI config (it's only necessary for `shopify-codemod`).