### PR TITLE
Fix default `modules` option

### DIFF
--- a/node.js
+++ b/node.js
@@ -3,7 +3,7 @@ var nonStandardPlugins = require('./non-standard-plugins');
 module.exports = function shopifyNodePreset(context, options) {
   options = options || {};
   var version = options.version || 'current';
-  var modules = options.modules == null ? true : options.modules;
+  var modules = options.modules == null ? 'commonjs' : options.modules;
 
   return {
     presets: [

--- a/web.js
+++ b/web.js
@@ -3,7 +3,7 @@ var nonStandardPlugins = require('./non-standard-plugins');
 
 module.exports = function shopifyWebPreset(context, options) {
   options = options || {};
-  var modules = options.modules == null ? true : options.modules;
+  var modules = options.modules == null ? 'commonjs' : options.modules;
 
   return {
     presets: [


### PR DESCRIPTION
This PR fixes the default value for `modules` for the web and node configs. `true` is not a valid option, you need to pass a string for one of the module options (we default to `commonjs`).