### PR TITLE
Update browser list to match vault page

### DIFF
--- a/browsers.js
+++ b/browsers.js
@@ -1,8 +1,8 @@
 module.exports = [
   'last 3 chrome versions',
   'last 3 firefox versions',
-  'last 2 versions',
+  'last 3 edge versions',
   'safari >= 10',
   'ios >= 10',
-  'android >= 6',
+  'last 3 chromeAndroid',
 ];

--- a/browsers.js
+++ b/browsers.js
@@ -2,9 +2,7 @@ module.exports = [
   'last 3 chrome versions',
   'last 3 firefox versions',
   'last 2 versions',
-  'safari >= 8',
-  'ios >= 8',
-  'ie >= 11',
-  'explorermobile >= 11',
-  'android >= 4.4',
+  'safari >= 10',
+  'ios >= 10',
+  'android >= 6',
 ];


### PR DESCRIPTION
- Dropping IE support
- Last two versions of Safari and IOS
- Update Android to 6; Latest is 8

Browser support [vault page](https://vault.shopify.com/Browser-Support#admin-and-1st-party-apps-and-channels)