### PR TITLE
Added support for pragma option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ This packages comes with several different presets for you to use, depending on 
 
 - `shopify/react`: Adds plugins that transform React (including JSX). You can use this preset with the `shopify/web` or `shopify/node` configuration. Note that if you enable this, you do not need to also enable the `shopify/flow` config (it is included automatically). You will, however, need to include an `Object.assign` polyfill in your bundle (we recommend the polyfills found in [`babel-polyfill`](https://babeljs.io/docs/usage/polyfill/)).
 
-  This preset accepts an options object. We accept a single option, `hot`, which will automatically add plugins to enable hot reloading of React components. Note that this requires you to have a recent version of `react-hot-loader` installed as a dependency in your project.
+  This preset accepts an options object.
+  - `hot` : Will automatically add plugins to enable hot reloading of React components. Note that this requires you to have a recent version of `react-hot-loader` installed as a dependency in your project.
+  - `pragma` : Replace the function used when compiling JSX expressions. defaults to `React.createElement`.
 
   ```json
   {

--- a/react.js
+++ b/react.js
@@ -2,10 +2,12 @@ module.exports = function shopifyReactPreset(context, options = {}) {
   // eslint-disable-next-line no-process-env
   const env = process.env.BABEL_ENV || process.env.NODE_ENV;
 
+  const pragma = options.pragma || 'React.createElement';
   const plugins = [
     // Make JSX spread operator use Object.assign instead of the Babel helper
     [require.resolve('babel-plugin-transform-react-jsx'), {
       useBuiltIns: true,
+      pragma,
     }],
   ];
 


### PR DESCRIPTION
## What
Adds the support for a pragma option in the `shopify/react` preset.

## Why
If we want to use a different pragma for JSX transformation we currently need to re-define the `transform-react-jsx` plugin and pass the custom pragma.

This should be possible directly through the preset IMO.

## How
Added the support for a `pragma` option in `react.js`. If it's not preset it will default to `React.createElement`, which is the plugin's default.

Updated the README to reflect the changes.