### PR TITLE
Added publishConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "name": "Shopify",
     "email": "dev@shopify.com"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://github.com/Shopify/babel-preset-shopify",
   "repository": "https://github.com/Shopify/babel-preset-shopify",
   "scripts": {


### PR DESCRIPTION
[Deploys are failing](https://shipit.shopify.io/shopify/babel-preset-shopify/production/deploys/560527) since it's missing the new `publishConfig` key from it's package.json

Link to the package cloud documentation https://development.shopify.io/guides/package_cloud_nodejs#1_Public_or_private_package 
