### PR TITLE
Use environment from the envName instead of BABEL_ENV / NODE_ENV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
-nil
+
+## Fixed
+
+- Honor the `envName` defined in your babel config.
 
 # 17.0.0
 ## Changed

--- a/node.js
+++ b/node.js
@@ -1,6 +1,6 @@
 const nonStandardPlugins = require('./non-standard-plugins');
 
-module.exports = function shopifyNodePreset(context, options = {}) {
+module.exports = function shopifyNodePreset(_api, options = {}) {
   const {
     version = 'current',
     modules = 'commonjs',

--- a/react.js
+++ b/react.js
@@ -1,6 +1,5 @@
-module.exports = function shopifyReactPreset(_context, options = {}) {
-  // eslint-disable-next-line no-process-env
-  const env = process.env.BABEL_ENV || process.env.NODE_ENV;
+module.exports = function shopifyReactPreset(api, options = {}) {
+  const env = api.env();
 
   const pragma = options.pragma || 'React.createElement';
   const pragmaFrag = options.pragmaFrag || 'React.Fragment';

--- a/web.js
+++ b/web.js
@@ -1,6 +1,6 @@
 const nonStandardPlugins = require('./non-standard-plugins');
 
-module.exports = function shopifyWebPreset(context, options = {}) {
+module.exports = function shopifyWebPreset(_api, options = {}) {
   const {modules = 'commonjs'} = options;
 
   return {


### PR DESCRIPTION
Babel 7 lets you specify an envName in its config and a way to check
that within plugins. Use that instead of checking BABEL_ENV and NODE_ENV
manually.

If envName is not specified then its default value is
`process.env.BABEL_ENV || process.env.NODE_ENV || "development"`
so we retain current behaviour (with the added bonus of it never being
undefined)

see https://babeljs.io/docs/en/options#envname
see https://babeljs.io/docs/en/config-files#apienv

---

Without this the `envName` as specified in things like https://github.com/Shopify/sewing-kit/pull/1096/files#diff-20e159310371162948148726f167275dR357 would not be honored

---

I've renamed that argument to `api` as that's what the docs call it