### PR TITLE
web preset now accepts a `useBuiltIn` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- ## Unreleased -->
 
+## 18.1.1 - 2019-05-03
+
+- `web` preset now accepts a `useBuiltIn` value (default = `usage`)
+
 ## 18.1.0 - 2019-04-22
 
 ### Added

--- a/web.js
+++ b/web.js
@@ -6,13 +6,14 @@ module.exports = function shopifyWebPreset(_api, options = {}) {
     corejs = 2,
     debug = false,
     browsers,
+    useBuiltIns = 'usage',
   } = options;
 
   return {
     presets: [
       [require.resolve('@babel/preset-env'), {
         modules,
-        useBuiltIns: 'usage',
+        useBuiltIns,
         corejs,
         targets: {
           browsers,


### PR DESCRIPTION
`usage` [is still experimental](https://babeljs.io/docs/en/babel-preset-env#usebuiltins-entry), and can bloat larger webpack applications with KBs of unnecessary metadata.