### PR TITLE
Add @babel/plugin-proposal-optional-catch-binding to node & web presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-<!-- ## Unreleased -->
+## Unreleased
+- Added `@babel/plugin-proposal-optional-catch-binding` to `node` presets
 
 ## 19.0.0 - 2019-05-06
 

--- a/non-standard-plugins.js
+++ b/non-standard-plugins.js
@@ -4,6 +4,7 @@ module.exports = function shopifyNonStandardPlugins(options = {}) {
   const plugins = [
     require.resolve('@babel/plugin-proposal-class-properties'),
     require.resolve('@babel/plugin-syntax-dynamic-import'),
+    require.resolve('@babel/plugin-proposal-optional-catch-binding'),
   ];
 
   if (inlineEnv) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@babel/core": "^7.4.3",
     "@babel/plugin-proposal-class-properties": "^7.4.0",
+    "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-react-constant-elements": "^7.2.0",
     "@babel/preset-env": "^7.4.3",


### PR DESCRIPTION
This adds `@babel/plugin-proposal-optional-catch-binding` so we can use the newer syntax (like sewing-kit v0.85.0 does) and should fix the following error that occurred when running tests on older versions of Node (8.12.0). 

```
  Details:

    /Users/jasongodson/src/github.com/Shopify/parsnip/node_modules/@shopify/sewing-kit/jest/transformers/typescript.js:6
    } catch {
            ^

    SyntaxError: Unexpected token {
```

I think it makes sense to add it to the `non-standard-plugins` as it looks like they apply to `node` and `web`, but let me know if there's a better spot.
 
Also let me know if I missed anything else 🙂
