### PR TITLE
Remove @babel/plugin-proposal-optional-catch-binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Removed `@babel/plugin-proposal-optional-catch-binding` because it is already handled by `@babel/preset-env` if you specify an environment where it is needed.
 
 ## 19.0.1 - 2019-05-23
 

--- a/non-standard-plugins.js
+++ b/non-standard-plugins.js
@@ -4,7 +4,6 @@ module.exports = function shopifyNonStandardPlugins(options = {}) {
   const plugins = [
     require.resolve('@babel/plugin-proposal-class-properties'),
     require.resolve('@babel/plugin-syntax-dynamic-import'),
-    require.resolve('@babel/plugin-proposal-optional-catch-binding'),
   ];
 
   if (inlineEnv) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@babel/core": "^7.4.3",
     "@babel/plugin-proposal-class-properties": "^7.4.0",
-    "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-react-constant-elements": "^7.2.0",
     "@babel/preset-env": "^7.4.3",


### PR DESCRIPTION
We don't need to explicitly state this as it already handled by
@babel/preset-env if you specify a target that requires it

See https://github.com/babel/babel/blob/eae7a333166eb76ed7e66f50efb7902fda4b247b/packages/babel-preset-env/data/plugins.json#L288

This commit reverts c110c84f